### PR TITLE
Add Expo fingerprint change detection and Discord notifications

### DIFF
--- a/.github/actions/build_mobile_eas/action.yml
+++ b/.github/actions/build_mobile_eas/action.yml
@@ -24,6 +24,9 @@ inputs:
   asc_app_id:
     description: 'ASC app ID'
     required: false
+  discord_webhook_url:
+    description: 'Discord webhook URL for fingerprint change notifications'
+    required: false
 
 runs:
   using: 'composite'
@@ -67,6 +70,7 @@ runs:
       EXPO_APP_PROFILE: ${{ inputs.profile }}
 
   - name: Compute expo fingerprint
+    id: fingerprint
     uses: expo/expo-github-action/continuous-deploy-fingerprint-info@main
     with:
       profile: ${{ inputs.profile }}
@@ -74,6 +78,45 @@ runs:
     env:
       APP_PROFILE: ${{ inputs.profile }}
       EXPO_APP_PROFILE: ${{ inputs.profile }}
+
+  - name: Check fingerprint changes and notify
+    if: ${{ inputs.discord_webhook_url != '' }}
+    shell: bash
+    run: |
+      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint"
+      if [ -f "$FINGERPRINT_FILE" ]; then
+        MAIN_ANDROID=$(jq -r '.android' "$FINGERPRINT_FILE")
+        MAIN_IOS=$(jq -r '.ios' "$FINGERPRINT_FILE")
+
+        CURRENT_ANDROID="${{ steps.fingerprint.outputs.android-fingerprint }}"
+        CURRENT_IOS="${{ steps.fingerprint.outputs.ios-fingerprint }}"
+
+        CHANGED=""
+        if [ -n "$CURRENT_ANDROID" ] && [ "$MAIN_ANDROID" != "$CURRENT_ANDROID" ]; then
+          CHANGED="Android fingerprint changed: $MAIN_ANDROID -> $CURRENT_ANDROID"
+        fi
+        if [ -n "$CURRENT_IOS" ] && [ "$MAIN_IOS" != "$CURRENT_IOS" ]; then
+          if [ -n "$CHANGED" ]; then
+            CHANGED="$CHANGED\niOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+          else
+            CHANGED="iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+          fi
+        fi
+
+        if [ -n "$CHANGED" ]; then
+          echo "Fingerprint changed, sending Discord notification..."
+          jq -n \
+            --arg changes "$CHANGED" \
+            --arg profile "${{ inputs.profile }}" \
+            --arg platform "${{ inputs.platform }}" \
+            '{"content": "⚠️ **Expo Fingerprint Changed** (build_mobile)\nProfile: \($profile) | Platform: \($platform)\n\($changes)\n\nA new native build may be required."}' | \
+          curl -X POST -H "Content-Type: application/json" -d @- "${{ inputs.discord_webhook_url }}"
+        else
+          echo "Fingerprint unchanged"
+        fi
+      else
+        echo "No fingerprint file found at $FINGERPRINT_FILE, skipping comparison"
+      fi
 
   - name: Prebuild expo app
     if: ${{ inputs.local == 'true' }}

--- a/.github/actions/build_mobile_eas/action.yml
+++ b/.github/actions/build_mobile_eas/action.yml
@@ -83,7 +83,7 @@ runs:
     if: ${{ inputs.discord_webhook_url != '' }}
     shell: bash
     run: |
-      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint"
+      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint.json"
       if [ -f "$FINGERPRINT_FILE" ]; then
         MAIN_ANDROID=$(jq -r '.android' "$FINGERPRINT_FILE")
         MAIN_IOS=$(jq -r '.ios' "$FINGERPRINT_FILE")

--- a/.github/actions/build_mobile_eas/action.yml
+++ b/.github/actions/build_mobile_eas/action.yml
@@ -97,7 +97,7 @@ runs:
         fi
         if [ -n "$CURRENT_IOS" ] && [ "$MAIN_IOS" != "$CURRENT_IOS" ]; then
           if [ -n "$CHANGED" ]; then
-            CHANGED="$CHANGED\niOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+            CHANGED="$CHANGED"$'\n'"iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
           else
             CHANGED="iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
           fi

--- a/.github/actions/update_mobile_eas/action.yml
+++ b/.github/actions/update_mobile_eas/action.yml
@@ -88,7 +88,7 @@ runs:
         fi
         if [ -n "$CURRENT_IOS" ] && [ "$MAIN_IOS" != "$CURRENT_IOS" ]; then
           if [ -n "$CHANGED" ]; then
-            CHANGED="$CHANGED\niOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+            CHANGED="$CHANGED"$'\n'"iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
           else
             CHANGED="iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
           fi

--- a/.github/actions/update_mobile_eas/action.yml
+++ b/.github/actions/update_mobile_eas/action.yml
@@ -74,7 +74,7 @@ runs:
     if: ${{ inputs.discord_webhook_url != '' }}
     shell: bash
     run: |
-      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint"
+      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint.json"
       if [ -f "$FINGERPRINT_FILE" ]; then
         MAIN_ANDROID=$(jq -r '.android' "$FINGERPRINT_FILE")
         MAIN_IOS=$(jq -r '.ios' "$FINGERPRINT_FILE")

--- a/.github/actions/update_mobile_eas/action.yml
+++ b/.github/actions/update_mobile_eas/action.yml
@@ -14,6 +14,9 @@ inputs:
   site_url:
     description: 'Site URL'
     required: true
+  discord_webhook_url:
+    description: 'Discord webhook URL for fingerprint change notifications'
+    required: false
 
 runs:
   using: 'composite'
@@ -56,6 +59,7 @@ runs:
       EXPO_APP_PROFILE: ${{ inputs.profile }}
 
   - name: Compute expo fingerprint
+    id: fingerprint
     uses: expo/expo-github-action/continuous-deploy-fingerprint-info@main
     with:
       profile: ${{ inputs.profile }}
@@ -65,6 +69,45 @@ runs:
       EXPO_PUBLIC_SITE_URL: ${{ inputs.site_url }}
       APP_PROFILE: ${{ inputs.profile }}
       EXPO_APP_PROFILE: ${{ inputs.profile }}
+
+  - name: Check fingerprint changes and notify
+    if: ${{ inputs.discord_webhook_url != '' }}
+    shell: bash
+    run: |
+      FINGERPRINT_FILE="apps/mobile/.expo-fingerprint"
+      if [ -f "$FINGERPRINT_FILE" ]; then
+        MAIN_ANDROID=$(jq -r '.android' "$FINGERPRINT_FILE")
+        MAIN_IOS=$(jq -r '.ios' "$FINGERPRINT_FILE")
+
+        CURRENT_ANDROID="${{ steps.fingerprint.outputs.android-fingerprint }}"
+        CURRENT_IOS="${{ steps.fingerprint.outputs.ios-fingerprint }}"
+
+        CHANGED=""
+        if [ -n "$CURRENT_ANDROID" ] && [ "$MAIN_ANDROID" != "$CURRENT_ANDROID" ]; then
+          CHANGED="Android fingerprint changed: $MAIN_ANDROID -> $CURRENT_ANDROID"
+        fi
+        if [ -n "$CURRENT_IOS" ] && [ "$MAIN_IOS" != "$CURRENT_IOS" ]; then
+          if [ -n "$CHANGED" ]; then
+            CHANGED="$CHANGED\niOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+          else
+            CHANGED="iOS fingerprint changed: $MAIN_IOS -> $CURRENT_IOS"
+          fi
+        fi
+
+        if [ -n "$CHANGED" ]; then
+          echo "Fingerprint changed, sending Discord notification..."
+          jq -n \
+            --arg changes "$CHANGED" \
+            --arg profile "${{ inputs.profile }}" \
+            --arg platform "${{ inputs.platform }}" \
+            '{"content": "⚠️ **Expo Fingerprint Changed** (update_mobile)\nProfile: \($profile) | Platform: \($platform)\n\($changes)\n\nA new native build may be required."}' | \
+          curl -X POST -H "Content-Type: application/json" -d @- "${{ inputs.discord_webhook_url }}"
+        else
+          echo "Fingerprint unchanged"
+        fi
+      else
+        echo "No fingerprint file found at $FINGERPRINT_FILE, skipping comparison"
+      fi
 
   - name: Send update to eas
     shell: bash

--- a/.github/workflows/build_mobile.yml
+++ b/.github/workflows/build_mobile.yml
@@ -93,6 +93,7 @@ jobs:
         output_logs: ${{ inputs.output_eas_build_to_logs || github.event.client_payload.output_eas_build_to_logs || false }}
         expo-token: ${{ secrets.EXPO_TOKEN }}
         asc_app_id: ${{ secrets.ASC_APP_ID }}
+        discord_webhook_url: ${{ secrets.DISCORD_APP_BUILDS_WEBHOOK_URL }}
 
     - name: Build Mobile App and Submit with EAS
       if: ${{ github.event.action == 'new-commit-on-main' }}
@@ -105,6 +106,7 @@ jobs:
         output_logs: false
         expo-token: ${{ secrets.EXPO_TOKEN }}
         asc_app_id: ${{ secrets.ASC_APP_ID }}
+        discord_webhook_url: ${{ secrets.DISCORD_APP_BUILDS_WEBHOOK_URL }}
 
     # - name: Build Mobile App with Gradle
     #   uses: ./.github/composite-actions/.github/actions/build_mobile_gradle

--- a/.github/workflows/update_mobile.yml
+++ b/.github/workflows/update_mobile.yml
@@ -77,3 +77,4 @@ jobs:
         profile: ${{ env.PROFILE }}
         expo-token: ${{ secrets.EXPO_TOKEN }}
         site_url: ${{ env.SITE_URL }}
+        discord_webhook_url: ${{ secrets.DISCORD_APP_BUILDS_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

This PR adds Expo fingerprint change detection to our EAS build and update workflows, with automatic Discord notifications when native dependencies change.

## Changes

### Modified Actions
**`.github/actions/build_mobile_eas/action.yml`:**
- Added `discord_webhook_url` input parameter
- Added `id: fingerprint` to the fingerprint computation step to capture outputs
- Added "Check fingerprint changes and notify" step that:
  - Reads baseline fingerprints from `.expo-fingerprint.json` in the songdrive repo
  - Compares with computed fingerprints for Android and iOS
  - Sends Discord notification if either fingerprint changed

**`.github/actions/update_mobile_eas/action.yml`:**
- Same changes as build_mobile_eas

### Modified Workflows
**`.github/workflows/build_mobile.yml`:**
- Both EAS build steps now pass `discord_webhook_url: ${{ secrets.DISCORD_APP_BUILDS_WEBHOOK_URL }}`

**`.github/workflows/update_mobile.yml`:**
- EAS update step now passes `discord_webhook_url: ${{ secrets.DISCORD_APP_BUILDS_WEBHOOK_URL }}`

## Related Work

**Companion PR in songdrive repo:** https://github.com/jamtools/songdrive/pull/326
- Adds the baseline `.expo-fingerprint.json` file that these workflows will compare against

## How It Works

1. During EAS build/update, the `expo/expo-github-action/continuous-deploy-fingerprint-info` action computes fingerprints
2. Our new step reads the baseline from `apps/mobile/.expo-fingerprint.json` in the songdrive repo
3. If current fingerprints differ from baseline, a Discord notification is sent to `DISCORD_APP_BUILDS_WEBHOOK_URL`
4. The notification includes which platform(s) changed and shows the old → new fingerprint values

## Discord Notification Format

```
⚠️ **Expo Fingerprint Changed** (build_mobile)
Profile: preview | Platform: all
Android fingerprint changed: 5419ded... -> abc123...
iOS fingerprint changed: 84763e5... -> def456...

A new native build may be required.
```

## Testing

- ✅ Actions syntax is valid
- ✅ Workflow syntax is valid
- ✅ Script logic tested locally
- ✅ Uses existing `DISCORD_APP_BUILDS_WEBHOOK_URL` secret (already configured for desktop builds)

## Next Steps

After both PRs are merged:
1. Verify Discord notifications work on the next build that changes fingerprints
2. Update the baseline file in songdrive repo whenever we intentionally change native dependencies
3. Monitor notifications to ensure we're aware of all native changes